### PR TITLE
Move navigation bar to left on Desktop screen

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -246,3 +246,24 @@ body {
 .contact a {
   text-decoration: none;
 }
+
+@media screen and (min-width: 840px) {
+  .app-layout {
+    flex-direction: row;
+  }
+
+  .app-navigation {
+    order: 1;
+  }
+
+  .app-content {
+    order: 2;
+  }
+
+  .navigation {
+    height: 100%;
+    width: 80px;
+    flex-direction: column;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
When the page is opened on a screen with width more than 840px, then move navigation bar to left of screen.