### PR TITLE
Modify home tab responsive for Desktop screen

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -266,4 +266,16 @@ body {
     flex-direction: column;
     justify-content: center;
   }
+
+  .home {
+    padding-left: 80px;
+    margin-left: 24px;
+    margin-right: 24px;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .home-heading {
+    margin-right: 24px;
+  }
 }


### PR DESCRIPTION
When page is loaded on screen with width more than 840px, then the heading and description is shown side by side.