### PR TITLE
Modify about tab responsive for Desktop screen

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -278,4 +278,20 @@ body {
   .home-heading {
     margin-right: 24px;
   }
+
+  .about {
+    padding-left: 80px;
+    margin-left: 24px;
+    margin-right: 24px;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .about-heading {
+    margin-right: 24px;
+  }
+
+  .about-description {
+    max-width: 600px;
+  }
 }


### PR DESCRIPTION
When page is loaded on screen with width more than 840px, then the heading and description is shown side by side.