### PR TITLE
Modify experience tab responsive for Desktop screen

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -193,6 +193,7 @@ body {
   padding: 12px 16px 80px 16px;
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .project-logo {
@@ -303,5 +304,15 @@ body {
     margin-right: 24px;
     flex-flow: row wrap;
     justify-content: center;
+    align-items: flex-start;
+  }
+
+  .projects {
+    padding-left: 80px;
+    margin-left: 24px;
+    margin-right: 24px;
+    flex-flow: row wrap;
+    justify-content: center;
+    align-items: flex-start;
   }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -158,9 +158,11 @@ body {
   padding: 12px 16px 80px 16px;
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .card {
+  max-width: 500px;
   border-radius: 12px;
   margin: 16px;
   padding: 16px;
@@ -293,5 +295,13 @@ body {
 
   .about-description {
     max-width: 600px;
+  }
+
+  .experience {
+    padding-left: 80px;
+    margin-left: 24px;
+    margin-right: 24px;
+    flex-flow: row wrap;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
When page is loaded on screen with width more than 840px, then the heading and description is shown side by side.