### PR TITLE
Fix navigation width

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -66,15 +66,16 @@ body {
   position: fixed;
   bottom: 0;
   z-index: 1;
+  overflow: scroll;
 }
 
 .navigation-item {
   padding: 12px;
   cursor: pointer;
+  flex: 1;
 }
 
 .navigation-icon {
-  width: 64px;
   height: 32px;
   border-radius: 16px;
   display: flex;
@@ -87,7 +88,6 @@ body {
 }
 
 .navigation-label {
-  width: 64px;
   height: 16px;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Navigation width was out of screen on mobile device. Fixed it by using flex: 1 for navigation item instead of fixing width of each item to 64px.