### PR TITLE
Replace vh to dvh

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -44,7 +44,7 @@ body {
 }
 
 .app-layout {
-  height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
vh is not supported in mobile so Google introduced dvh. Replaced vh to dvh to prevent unnecessary scrolling in mobile.