### PR TITLE
Fix navigation to center in Desktop screen

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -270,6 +270,10 @@ body {
     justify-content: center;
   }
 
+  .navigation-item {
+    flex: 0;
+  }
+
   .home {
     padding-left: 80px;
     margin-left: 24px;


### PR DESCRIPTION
Fixing navigation width for mobile view streched its height to full in desktop view. Fixed it by setting flex to 0 for each navigation item.